### PR TITLE
rr_hw_interface -> low_level_interfaces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set(PKG_DEPS
   roscpp
   std_msgs
   message_generation
-  rr_hw_interface
+  low_level_interfaces
 )
 
 

--- a/include/vl53l0x_driver/vl53l0x_driver.hpp
+++ b/include/vl53l0x_driver/vl53l0x_driver.hpp
@@ -16,7 +16,7 @@ extern "C" {
 #include "vl53l0x_platform.h"
 
 #include "vl53l0x_driver/vl53l0x.h"
-#include <rr_hw_interface/gpio/mcp23017_gpio.hpp>
+#include <low_level_interfaces/gpio/mcp23017_gpio.hpp>
 
 #define FIELD_OF_VIEW 0.436332
 #define MIN_RANGE 0.03

--- a/package.xml
+++ b/package.xml
@@ -15,7 +15,7 @@
   <build_depend>geometry_msgs</build_depend>
   <build_depend>message_generation</build_depend>
   <!--build_depend>vl53l0x</build_depend-->
-  <build_depend>rr_hw_interface</build_depend>
+  <build_depend>low_level_interfaces</build_depend>
 
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
@@ -23,6 +23,6 @@
   <run_depend>message_runtime</run_depend>
   <run_depend>message_generation</run_depend>
   <!--<run_depend>vl53l0x</run_depend-->
-  <run_depend>rr_hw_interface</run_depend>
+  <run_depend>low_level_interfaces</run_depend>
 
 </package>

--- a/src/vl53l0x_driver.cpp
+++ b/src/vl53l0x_driver.cpp
@@ -14,7 +14,7 @@ extern "C" {
 #include "vl53l0x_platform.h"
 
 #include "vl53l0x_driver/vl53l0x.h"
-#include <rr_hw_interface/gpio/mcp23017_gpio.hpp>
+#include <low_level_interfaces/gpio/mcp23017_gpio.hpp>
 #include <vl53l0x_driver/vl53l0x_driver.hpp>
 
 #define MCP_ADDRESS 0x20


### PR DESCRIPTION
There is currently no .rosinstall or submodule for this, so we should also make a .rosinstall if that is the path we are going to take.